### PR TITLE
Fix updating reports

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,10 +19,26 @@ jobs:
       - run: go generate ./...
       - run: go test ./...
       - run: go build
-      - name: golangci-lint
-        uses: golangci/golangci-lint-action@v2
+
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/setup-go@v4
         with:
-          version: v1.46
+          go-version: 1.18.x
+          cache: false
+      - uses: actions/checkout@v3
+      - run: go install github.com/deepmap/oapi-codegen/cmd/oapi-codegen@v1.11.0
+      - run: go generate ./...
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v3
+        with:
+          version: v1.52
+
+  release:
+    needs: [build, lint]
+    runs-on: ubuntu-latest
+    steps:
       - if: startsWith(github.ref, 'refs/tags/v')
         run: echo "$DOCKER_PASS" | docker login ghcr.io --username "$DOCKER_USER" --password-stdin
         env:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,5 +1,5 @@
 name: build
-on: [push, pull_request]
+on: [push]
 
 jobs:
   build:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,8 +1,8 @@
-name: build
+name: Build
 on: [push]
 
 jobs:
-  build:
+  test:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/setup-go@v2
@@ -34,20 +34,3 @@ jobs:
         uses: golangci/golangci-lint-action@v3
         with:
           version: v1.52
-
-  release:
-    needs: [build, lint]
-    runs-on: ubuntu-latest
-    steps:
-      - if: startsWith(github.ref, 'refs/tags/v')
-        run: echo "$DOCKER_PASS" | docker login ghcr.io --username "$DOCKER_USER" --password-stdin
-        env:
-          DOCKER_USER: ${{ github.repository_owner }}
-          DOCKER_PASS: ${{ secrets.GITHUB_TOKEN }}
-      - if: startsWith(github.ref, 'refs/tags/v')
-        uses: goreleaser/goreleaser-action@v2
-        with:
-          version: latest
-          args: release --skip-validate
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,22 @@
+on:
+  workflow_run:
+    workflows: [Build]
+    types: [completed]
+    branches:
+      - main
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    if: github.event.workflow_run.conclusion == 'success' && startsWith(github.ref, 'refs/tags/v')
+    steps:
+      - run: echo "$DOCKER_PASS" | docker login ghcr.io --username "$DOCKER_USER" --password-stdin
+        env:
+          DOCKER_USER: ${{ github.repository_owner }}
+          DOCKER_PASS: ${{ secrets.GITHUB_TOKEN }}
+      - uses: goreleaser/goreleaser-action@v2
+        with:
+          version: latest
+          args: release --skip-validate
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/database/test.go
+++ b/database/test.go
@@ -84,7 +84,7 @@ func UpdateFlakyTests(db *sqlx.DB, commitID int) error {
 	stmt, err := db.Preparex(`
 	UPDATE tests SET flaky = true
 		WHERE tests.id in (
-			SELECT DISTINCT(tests.id), tests.name FROM results
+			SELECT DISTINCT(tests.id) FROM results
 			LEFT JOIN tests ON tests.id = results.test_id
 			WHERE results.commit_id == ?
 			GROUP BY results.test_id


### PR DESCRIPTION
If there were already some (successful) reports for the same commitId, uploading artifacts always failed, because the wrong amount of columns was returned by the inner SELECT statement.

The following error was returned by the server in that case: "{"description":"couldn't update flaky tests: sub-select returns 2 columns - expected 1","error":"Internal Server Error"}"

Therefore, a lot of flaky test runs were probably never actually counted.