### PR TITLE
CI: Fix release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,6 @@ on:
   workflow_run:
     workflows: [Build]
     types: [completed]
-    branches: [main]
 
 jobs:
   release:


### PR DESCRIPTION
Specifying the branch name as condition for the workflow doesn't work if the preceding workflow was triggered by pushing a tag. And since an additional condition for the release job is the presence of a version tag, we can assume that this is only done on the default branch.