### PR TITLE
CI: Trigger release workflow only on release event

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,13 +1,12 @@
 name: Release
 on:
-  workflow_run:
-    workflows: [Build]
-    types: [completed]
+  release:
+    types: [published]
 
 jobs:
   release:
     runs-on: ubuntu-latest
-    if: github.event.workflow_run.conclusion == 'success' && startsWith(github.ref, 'refs/tags/v')
+    if: startsWith(github.ref, 'refs/tags/v')
     steps:
       - run: echo "$DOCKER_PASS" | docker login ghcr.io --username "$DOCKER_USER" --password-stdin
         env:

--- a/README.md
+++ b/README.md
@@ -109,3 +109,8 @@ Step 6/6 : ENTRYPOINT ["/opt/noflake/noflake"]
 Successfully built 76ad7efec763
 Successfully tagged noflake:local
 ```
+
+### Releasing a new version
+
+Please create a new release [via GitHub](https://github.com/FACT-Finder/noflake/releases/new) on a new tag. 
+This will trigger our release workflow which pushes the newest image to the docker registry.


### PR DESCRIPTION
The previous solution didn't work because the GITHUB_REF always references the default branch and not the ref which initially triggered the "Build" workflow. Now the workflow is triggered when a release is published via GitHub. We assume that this is only done for successful builds.